### PR TITLE
mousemove on touch screen prevents triggering of the event

### DIFF
--- a/jquery.longclick.js
+++ b/jquery.longclick.js
@@ -69,7 +69,7 @@
         /* normal technique for standard mouse-based interaction */
         $(this)
         .bind(_mousedown_, schedule)
-        .bind([_mousemove_, _mouseup_, _mouseout_, _contextmenu_].join(' '), annul)
+        .bind([_mouseup_, _mouseout_, _contextmenu_].join(' '), annul)
         .bind(_click_, click)
       }else{
         /* and special handling for touch-based interaction on iPhone-compatibile devices */


### PR DESCRIPTION
Hi, I'm running the code on a touch screen and it's very difficult to keep your hand absolutely still to trigger the long click event. Removing the mousemove restriction fixes this issue. Is this something you might want to consider applying to the main branch?
