### PR TITLE
change deprecated function to support jquery 1.9

### DIFF
--- a/jquery.longclick.js
+++ b/jquery.longclick.js
@@ -114,7 +114,7 @@
       /* Flag as "fired" and rejoin the default event flow */
       $(element).data(_fired_, true)
       event.type= type
-      jQuery.event.handle.apply(element, args)
+      jQuery.event.dispatch.apply(element, args)
     }
   }
   function annul(event){


### PR DESCRIPTION
jQuery.event.handle has been replaced by jQuery.event.dispatch
